### PR TITLE
feat: update repo URL to `voxpupuli.org`

### DIFF
--- a/source/apt/openvox7-release.list.template
+++ b/source/apt/openvox7-release.list.template
@@ -1,2 +1,2 @@
 # OpenVox 7 __CODENAME__ Repository
-deb [signed-by=/etc/apt/keyrings/openvox-keyring.gpg] https://apt.overlookinfratech.com __CODENAME__ openvox7
+deb [signed-by=/etc/apt/keyrings/openvox-keyring.gpg] https://apt.voxpupuli.org __CODENAME__ openvox7

--- a/source/apt/openvox8-release.list.template
+++ b/source/apt/openvox8-release.list.template
@@ -1,2 +1,2 @@
-# OpenVox 8 __CODENAME__ Repository
-deb [signed-by=/etc/apt/keyrings/openvox-keyring.gpg] https://apt.overlookinfratech.com __CODENAME__ openvox8
+voxpupuli.orgE__ Repository
+deb [signed-by=/etc/apt/keyrings/openvox-keyring.gpg] https://apt.voxpupuli.org __CODENAME__ openvox8

--- a/source/apt/openvox8-release.list.template
+++ b/source/apt/openvox8-release.list.template
@@ -1,2 +1,2 @@
-voxpupuli.orgE__ Repository
+# OpenVox 8 __CODENAME__ Repository
 deb [signed-by=/etc/apt/keyrings/openvox-keyring.gpg] https://apt.voxpupuli.org __CODENAME__ openvox8

--- a/source/yum/openvox7-release.repo.template
+++ b/source/yum/openvox7-release.repo.template
@@ -1,6 +1,6 @@
 [openvox7]
 name=OpenVox 7 Repository __OS_NAME__ __OS_VERSION__ - $basearch
-baseurl=https://yum.overlookinfratech.com/openvox7/__OS_NAME__/__OS_VERSION__/$basearch
+baseurl=https://yum.voxpupuli.org/openvox7/__OS_NAME__/__OS_VERSION__/$basearch
 gpgkey=file:///etc/pki/rpm-gpg/GPG-KEY-openvox-openvox7-release
 enabled=1
 gpgcheck=1

--- a/source/yum/openvox7-release.sles.template
+++ b/source/yum/openvox7-release.sles.template
@@ -1,6 +1,6 @@
 [openvox7]
 name=OpenVox 7 Repository __OS_NAME__ __OS_VERSION__ - $basearch
-baseurl=https://yum.overlookinfratech.com/openvox7/__OS_NAME__/__OS_VERSION__/$basearch
+baseurl=https://yum.voxpupuli.org/openvox7/__OS_NAME__/__OS_VERSION__/$basearch
 gpgkey=file:///etc/pki/rpm-gpg/GPG-KEY-openvox-openvox7-release
 enabled=1
 gpgcheck=1

--- a/source/yum/openvox8-release.repo.template
+++ b/source/yum/openvox8-release.repo.template
@@ -1,6 +1,6 @@
 [openvox8]
 name=OpenVox 8 Repository __OS_NAME__ __OS_VERSION__ - $basearch
-baseurl=https://yum.overlookinfratech.com/openvox8/__OS_NAME__/__OS_VERSION__/$basearch
+baseurl=https://yum.voxpupuli.org/openvox8/__OS_NAME__/__OS_VERSION__/$basearch
 gpgkey=file:///etc/pki/rpm-gpg/GPG-KEY-openvox-openvox8-release
 enabled=1
 gpgcheck=1

--- a/source/yum/openvox8-release.sles.template
+++ b/source/yum/openvox8-release.sles.template
@@ -1,6 +1,6 @@
 [openvox8]
 name=OpenVox 8 Repository __OS_NAME__ __OS_VERSION__ - $basearch
-baseurl=https://yum.overlookinfratech.com/openvox8/__OS_NAME__/__OS_VERSION__/$basearch
+baseurl=https://yum.voxpupuli.org/openvox8/__OS_NAME__/__OS_VERSION__/$basearch
 gpgkey=file:///etc/pki/rpm-gpg/GPG-KEY-openvox-openvox8-release
 enabled=1
 gpgcheck=1


### PR DESCRIPTION
Just a small change to get the release files to use the mirrors from <https://voxpupuli.org/blog/2025/03/04/openvox-downloads-and-mirroring/>.

If this is too early w.r.t. https://github.com/OpenVoxProject/planning/issues/50 please feel free to delay this until it's appropriate to change.

I assume this could lessen the load on OSL and could be appreciated because of <https://osuosl.org/blog/osl-future/>.

WDYT?

/cc @binford2k @genebean